### PR TITLE
fix an arg naming issue

### DIFF
--- a/src/jsonmenu.c
+++ b/src/jsonmenu.c
@@ -121,7 +121,7 @@ static int json_menu_init ( Mode* sw )
                 NULL
             };
 
-            pd->icon_themes = g_strdupv ( ( char ** ) find_arg_strv ( "-json-menu-theme" ) );
+            pd->icon_themes = g_strdupv ( ( char ** ) find_arg_strv ( "-json-menu-icon-theme" ) );
             if ( pd->icon_themes == NULL ) {
                 pd->icon_themes = g_strdupv ( ( char ** ) default_icon_themes );
             }


### PR DESCRIPTION
Doing it this way because you're not changing rofi's theme you're changing the icon theme.

Tho I'd recommend (if it's practical) to detect the system theme and use that.